### PR TITLE
Fix VB 5.0 Runtime bugs

### DIFF
--- a/vb5runtime/tools/chocolateyInstall.ps1
+++ b/vb5runtime/tools/chocolateyInstall.ps1
@@ -9,7 +9,7 @@ try {
   $scriptPath = Split-Path -parent $MyInvocation.MyCommand.Definition
   $ahkFile = "$scriptPath\vb5runtime.ahk"
   
-  NewItem $filePath -directory -force
+  New-Item $filePath -directory -force
   Get-ChocolateyWebFile $packageName $fileFullPath $url
   
   Start-Process 'AutoHotkey' $ahkFile

--- a/vb5runtime/vb5runtime.nuspec
+++ b/vb5runtime/vb5runtime.nuspec
@@ -17,7 +17,7 @@ This package contains all the necessary files for running applications created u
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <!--<iconUrl></iconUrl>-->
     <dependencies>
-      <dependency id="autohotkey_l.portable" />
+      <dependency id="autohotkey.portable" />
     </dependencies>
     <!--<releaseNotes></releaseNotes>-->
   </metadata>


### PR DESCRIPTION
> Please fix this and re-submit:
>
>The dependency should be changed to “autohotkey.portable”. The autohotkey_l packages are deprecated.
> Does the installer offer no silent installation and is autohotkey really required here?
> The installation fails with an error:

```
vb5runtime v5.0

Write-Error : vb5runtime did not finish successfully. Boo to the chocolatey gods!

[ERROR] The term 'NewItem' is not recognized as the name of a cmdlet, function, script file, or operable program. Check

the spelling of the name, or if a path was included, verify that the path is correct and try again.

At C:\ProgramData\chocolatey\chocolateyinstall\helpers\functions\Write-ChocolateyFailure.ps1:30 char:3
+ Write-Error $errorMessage
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo : NotSpecified: (:) [Write-Error], WriteErrorException
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Write-Error

Write-Error : Package 'vb5runtime v5.0' did not install successfully: The term 'NewItem' is not recognized as the name
of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, ver
ify that the path is correct and try again.
At C:\ProgramData\chocolatey\chocolateyinstall\functions\Chocolatey-NuGet.ps1:90 char:17
+ Write-Error "Package `'$installedPackageName v$installedPackageV ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo : NotSpecified: (:) [Write-Error], WriteErrorException
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Write-Error
```
